### PR TITLE
Remove specific python-dateutil version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=1.4.3
 djangorestframework>=2.1.15
 msgpack-python>=0.2.4
-python-dateutil==2.1
+python-dateutil>=2.1


### PR DESCRIPTION
python-dateutil 2.1 is old (we are on 2.4.x these days)

Behavior of the parse function hasn't materially changed.  Ran tests on python-dateutil 2.4.2.  I'd say its safe to just have a minimum bound requirement.
