### PR TITLE
Change requirement, from msgpack-python to msgpack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=1.8
 djangorestframework>=2.1.15
-msgpack-python>=0.2.4
+msgpack
 python-dateutil>=2.1


### PR DESCRIPTION
The PyPI package name msgpack-python is deprecated, see:
 https://github.com/msgpack/msgpack-python#pypi-package-name