### PR TITLE
Updated supported Python, Django and DRF version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,28 @@
+dist: xenial
 language: python
+
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+
 env:
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9
-  - DJANGO_VERSION=1.10
+  - DJANGO_VERSION=">=1.11,<2"
+  - DJANGO_VERSION=">=2.1,<2.2"
+  - DJANGO_VERSION=">=2.2,<2.3"
+  - DRF_VERSION=">=3.8,<3.9"
+  - DRF_VERSION=">3.9,<3.10"
+
+matrix:
+  exclude:
+  - python: 2.7
+    env: DJANGO_VERSION=">=2.1,<2.2"
+  - python: 2.7
+    env: DJANGO_VERSION=">=2.2,<2.3"
+
 install:
-  - pip install -q Django==$DJANGO_VERSION
-  - pip install -q -r requirements.txt
+  - pip install -q "msgpack-python>=0.5.6" "python-dateutil>=2.8"
+  - pip install "djangorestframework${DRF_VERSION}" "django${DJANGO_VERSION}"
+
 script: python manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     env: DJANGO_VERSION=">=2.2,<2.3"
 
 install:
-  - pip install -q "msgpack-python>=0.5.6" "python-dateutil>=2.8"
+  - pip install -q "msgpack>=0.6.1" "python-dateutil>=2.8"
   - pip install "djangorestframework${DRF_VERSION}" "django${DJANGO_VERSION}"
 
 script: python manage.py test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.8
-djangorestframework>=2.1.15
-msgpack-python>=0.2.4
-python-dateutil>=2.1
+Django>=1.11
+djangorestframework>=3.9,<3.10
+msgpack-python>=0.5.6
+python-dateutil>=2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=1.11
 djangorestframework>=3.9,<3.10
-msgpack-python>=0.5.6
+msgpack>=0.6.1
 python-dateutil>=2.8

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP'
     ]
 )


### PR DESCRIPTION
This changes brings the requirements to currently maintained versions of each software:

* Python 2.7, 3.5~3.7
* Django 1.11, 2.1, 2.2
* DRF 3.8, 3.9
* `msgpack-python` to `msgpack` (same reasoning as #13)

Travis integration has been updated to test all possible version combination scenarios
so that tests are more reliable.

More tests were added to bring code coverage to 100%